### PR TITLE
Add options to send webp paths to lottie-scroll directive

### DIFF
--- a/src/angular/directive-lazy-image.ts
+++ b/src/angular/directive-lazy-image.ts
@@ -66,7 +66,7 @@ export class LazyImage implements INgDisposable {
         this.imageSet = false;
 
         // Cache this value since is.supportingWebp can be computationally expensive.
-        is.supportingWebpAsync().then((supporting)=> {
+        is.supportingWebpAsync().then((supporting) => {
             this.isWebpSupported = supporting;
 
             this.watcher = new DomWatcher();


### PR DESCRIPTION
This is a stopgap until we have deeper Google image service support for Lottie files. This allows the user to manually specify a JSON path to the Lottie.

Is this OK to add here? An alternative design would be to replace the JSON path within the Lottie object beforehand with the WebP path, but I think I like this better because it keeps the data structure in YAML and the JS implementation coupled.