### PR TITLE
Add noop. Does nothing, but on purpose.

### DIFF
--- a/src/func/noop.ts
+++ b/src/func/noop.ts
@@ -6,4 +6,6 @@
  * It does nothing, but on purpose and doesn't look like a bug or error.
  * It exists solely for readability.
  */
-export function noop(...args: any[]): any {}
+export function noop(...args: any[]): any {
+  // Purposefully empty.
+}

--- a/src/func/noop.ts
+++ b/src/func/noop.ts
@@ -1,0 +1,9 @@
+/**
+ * Does nothing. Use when you need to do nothing and want to make it clear that
+ * you fully understood you were doing nothing and really truly intended to do
+ * nothing.
+ *
+ * It does nothing, but on purpose and doesn't look like a bug or error.
+ * It exists solely for readability.
+ */
+export function noop(...args: any[]): any {}


### PR DESCRIPTION
Useful to make it clear that `() => {}` wasn't an error, and isn't incomplete.

Also has nice `any` typing so it can be used everywhere you really want to do nothing.