### PR TITLE
Add mathf.getSign

### DIFF
--- a/src/mathf/mathf.ts
+++ b/src/mathf/mathf.ts
@@ -1397,4 +1397,10 @@ export class mathf {
     return mathf.lerp(minA, maxA, t);
   }
 
+  static getSign(x: number): number {
+    return !Math.sign ?
+        // Use MDN polyfill for math.sign
+        (<number><unknown>(x > 0) - <number><unknown>(x < 0)) || +x :
+        Math.sign(x);
+  }
 }


### PR DESCRIPTION
If yano-js does not need to support IE we can ignore this
and use Math.sign directly. Not sure what support we want
to consider.