### PR TITLE
fix: unsetFocusableElementsToTabIndex coverage

### DIFF
--- a/src/dom/dom.ts
+++ b/src/dom/dom.ts
@@ -973,13 +973,14 @@ export function setFocusableElementsToTabIndex(
  * after the 'dom.setFocusableElementsToTabIndex()` method has been executed.
  */
 export function unsetFocusableElementsToTabIndex(element: HTMLElement) {
-  const elements: HTMLElement[] = getFocusableElements(element);
+  const elements: HTMLElement[] = Array.from(
+    element.querySelectorAll('[originalTabIndex]')
+  );
 
   elements.forEach(element => {
-    if (element.hasAttribute('originalTabIndex')) {
-      const originalTabIndex = !element.getAttribute('originalTabIndex');
-      element.tabIndex = +originalTabIndex;
-    }
+    const originalTabIndex: string =
+      element.getAttribute('originalTabIndex') || '';
+    element.tabIndex = +originalTabIndex;
   });
 }
 


### PR DESCRIPTION
Elements with a tabindex of -1 were being ignored due to their
exclusion from results in getFocusableElements.

By querying for elements with the originalTabIndex attr instead it
ensures all elements who had that value set by setFocusableElementsToTabIndex
are included and their tabindex reset.