### PR TITLE
fix: make youtube api publicly accessible

### DIFF
--- a/src/components/youtube-inline.ts
+++ b/src/components/youtube-inline.ts
@@ -85,7 +85,7 @@ export class DeguYouTubeInline extends LitElement {
   @query('.container__player')
   playerElement: HTMLElement;
 
-  private player?: YT.Player;
+  public player?: YT.Player;
 
   connectedCallback() {
     super.connectedCallback();


### PR DESCRIPTION
Hey @uxder,

Have a use case where I need to jump to specific timestamps with [seekTo](https://developers.google.com/youtube/iframe_api_reference#seekTo). Can we make the Youtube Api publicly accessible for this component? 